### PR TITLE
Google data already in array form

### DIFF
--- a/extensions/adapter/geo/Google.php
+++ b/extensions/adapter/geo/Google.php
@@ -40,7 +40,9 @@ class Google extends Base {
 		parent::_init();
 
 		$parse = function($data) {
-			$data = json_decode($data, true);
+			if (!is_array($data)) {
+				$data = json_decode($data, true);
+			}	
 			if (!isset($data['results'][0])) {
 				return false;
 			}


### PR DESCRIPTION
When using the Google adapter, it seems that $data is already an array, so json_decode throws a warning.

I figure a safe modification is to check if the data is already an array.

Hopefully I'm not missing something, but without this, geocoding by address is entirely broken.
